### PR TITLE
Update Runtime to 25.08

### DIFF
--- a/io.github.xyproto.zsnes.yaml
+++ b/io.github.xyproto.zsnes.yaml
@@ -1,6 +1,6 @@
 id: io.github.xyproto.zsnes
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: zsnes
 finish-args:
@@ -18,12 +18,12 @@ sdk-extensions:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '24.08'
+    version: '25.08'
 
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: '1.4'
-    versions: 24.08;1.4
+    versions: 25.08;1.4
     subdirectories: true
     no-autodownload: true
     autodelete: false


### PR DESCRIPTION
This updates the Runtime to 25.08. The new Runtime uses SDL3 instead of SDL2. So the way ZSNES works is now basically sdl12-compat > sdl2-compat > SDL3.

The Mouse currently feels weird in Fullscreen, but I don't know what's causing this. This problem doesn't occur on my host system (ArchLinux), which also uses sdl2-compat  @xyproto Any idea what's causing this?